### PR TITLE
emulated LED colors wrong

### DIFF
--- a/firmware/emu/swadgemu.c
+++ b/firmware/emu/swadgemu.c
@@ -442,9 +442,9 @@ void ws2812_push( uint8_t* buffer, uint16_t buffersize )
 	for( ; led < buffersize/3; led++ )
 	{
 		uint32_t col = 0xff000000;
-		col |= buffer[led*3+2]<<16;
-		col |= buffer[led*3+0]<<8;
-		col |= buffer[led*3+1]<<0;
+		col |= buffer[led*3+1]<<16; // r
+		col |= buffer[led*3+0]<<8;  // g
+		col |= buffer[led*3+2]<<0;  // b
 		ws2812s[led] = col;
 	}
 }

--- a/firmware/user/user_main.c
+++ b/firmware/user/user_main.c
@@ -673,12 +673,12 @@ void ICACHE_FLASH_ATTR swadgeModeEspNowSendCb(uint8_t* mac_addr, mt_tx_status st
  *==========================================================================*/
 
 /**
- * Set the state of the six RGB LEDs, but don't overwrite if the LEDs were
+ * Set the state of the six GRB LEDs, but don't overwrite if the LEDs were
  * set via UDP for at least TICKER_TIMEOUT increments of 100ms
  *
  * @param ledData Array of LED color data. Every three bytes corresponds to
- * one LED in RGB order. So index 0 is LED1_R, index 1 is
- * LED1_G, index 2 is LED1_B, index 3 is LED2_R, etc.
+ * one LED in GRB order. So index 0 is LED1_G, index 1 is
+ * LED1_R, index 2 is LED1_B, index 3 is LED2_G, etc.
  * @param ledDataLen The length of buffer, most likely 6*3
  */
 void ICACHE_FLASH_ATTR setLeds(led_t* ledData, uint16_t ledDataLen)


### PR DESCRIPTION
Note also  gamma correction prob should not be used for the emu LEDs will raise this as issue.
(If run test mode, will not see LEDs with intensity 16 in emu. 0xff, 0x7f, 0x3f can be seen).