### PR TITLE
Flips up and down souls in ddr mode

### DIFF
--- a/firmware/user/modes/mode_ddr.c
+++ b/firmware/user/modes/mode_ddr.c
@@ -622,15 +622,17 @@ static void ICACHE_FLASH_ATTR ddrUpdateDisplay(void* arg __attribute__((unused))
                 switch(rowIdx)
                 {
                     default:
-                    case 1:
-                        break;
                     case 0:
                         rowRot = 90;
+                        rowHFlip = false;
+                    case 1:
+                        break;
                     case 2:
                         rowHFlip = true;
                         break;
                     case 3:
                         rowRot = 270;
+                        rowHFlip = true;
                         break;
                 }
 


### PR DESCRIPTION
Flips up and down lost souls to be rightside-up when device is rotated to put targets at top of screen